### PR TITLE
Update wrappedexec.js

### DIFF
--- a/wrappedexec.js
+++ b/wrappedexec.js
@@ -6,6 +6,8 @@ const execWrapPath = require.resolve('./exec-wrap')
     , xtend        = require('xtend')
     , after        = require('after')
 
+os.tmpDir = os.tmpdir
+
 function fix (exercise) {
   var dataPath = path.join(os.tmpDir(), '~workshopper.wraptmp.' + process.pid)
   var submissionPath = dataPath + '-submission'


### PR DESCRIPTION
Fix bug on the tmpDir method. It seems to be deprecated and only tmpdir() exists in the os packages. The line added allow both writing.